### PR TITLE
CitusDB 6.0 Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use postgres 9.5 base image, and extend it
-FROM postgres:9.5
+# Use postgres 9.6 base image, and extend it
+FROM postgres:9.6
 
 MAINTAINER Tyler Montgomery <http://github.com/thecubed>
 
@@ -7,7 +7,7 @@ MAINTAINER Tyler Montgomery <http://github.com/thecubed>
 RUN apt-get -y update && \
 	apt-get -y install curl && \
 	curl -s https://packagecloud.io/install/repositories/citusdata/community/script.deb.sh | bash && \
-	apt-get -y install postgresql-9.5-citus unzip
+	apt-get -y install postgresql-9.6-citus=6.0.0.citus-1 unzip
 
 # Add our scripts to manage CitusDB
 ADD *.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Before this can be merged, the following tasks must be finished:
- [x] Update to Postgres 9.6
- [x] Use CitusDB 6.0.0 packages
- [ ] Switch to CitusDB 6.X method of adding workers

The using 6.X's method of adding/removing workers will entail changing Consul Template to generate SQL statements to add workers dynamically. Removing workers from the pool will be more difficult.